### PR TITLE
Fix Gap on Homescreen and Pick a Test Page

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -6,20 +6,18 @@ import Header from "./Header";
 const Layout = ({ children, className }) => {
   const { pathname } = useRouter();
   return (
-    <div className="flex flex-col min-h-screen justify-between gap-5">
-
+    <div className="flex flex-col min-h-screen justify-between">
       {pathname === "/sign-up" ||
       pathname === "/sign-in" ||
       pathname === "/choose-test" ? null : (
         <Header className={className} />
       )}
       <main
-        className={`${className} text-white pt-[3rem] flex justify-center items-center flex-1`}
+        className={`${className} text-white  flex justify-center items-center flex-1`}
       >
         {children}{" "}
       </main>
-      {pathname === "/sign-up" |
-      pathname === "/sign-in" ||
+      {(pathname === "/sign-up") | (pathname === "/sign-in") ||
       pathname === "/choose-test" ? null : (
         <Footer className={className} />
       )}

--- a/components/Onboarding/Onboarding.js
+++ b/components/Onboarding/Onboarding.js
@@ -27,7 +27,7 @@ const FirstStep = () => {
     >
       <div className=" md:grid md:grid-cols-10 lg:gap-36">
         {/* Left Column */}
-        <div className="flex flex-col items-center px-10 py-40 md:grid md:items-start md:col-span-4 md:pr-0 md:pl-20">
+        <div className="flex flex-col items-center px-10 py-20 md:grid md:items-start md:col-span-4 md:pr-0 md:pl-20">
           <div className="text-center  md:text-left">
             <h1 className="text-[1.3rem] font-semibold ">Hackathon 4.0 🔥</h1>
             <p className="font-medium text-[#06BA6B] text-4xl mt-5">
@@ -74,7 +74,7 @@ const FirstStep = () => {
 
         {/* Right Column */}
         <div
-          className="col-span-5 mt-28 h-[80%] md:relative text-white hidden md:flex"
+          className="col-span-5 mt-16 h-[80%] md:relative text-white hidden md:flex"
           style={{
             backgroundImage: "url(/homeside.jpg)",
             backgroundRepeat: "no-repeat",

--- a/pages/choose-test.js
+++ b/pages/choose-test.js
@@ -43,7 +43,7 @@ function ChooseTest() {
   };
 
   return (
-    <section className="flex flex-col bg  gap-5 p-5 max-w-[700px]">
+    <section className="flex flex-col bg gap-5 mt-16 md:mt-0 p-5 max-w-[700px]">
       <div
         onClick={() => router.back()}
         className="fixed top-[5vh] left-[5vh] flex items-center"


### PR DESCRIPTION
- Removed Gap and Margin-Top from Layout to Fix the Homescreen
- Add Margin-Top to Pick a Test Screen to fix Text moving under the Go Back button
-  Reduced Padding and Margin from Both Columns on Homescreen to Fit between Header and Footer